### PR TITLE
Add option to serialize UTF-8 strings directly

### DIFF
--- a/include/cxxtools/jsonformatter.h
+++ b/include/cxxtools/jsonformatter.h
@@ -41,7 +41,8 @@ namespace cxxtools
                 : _ts(0),
                   _level(1),
                   _lastLevel(0),
-                  _beautify(false)
+                  _beautify(false),
+                  _inputUtf8(false)
             {
             }
 
@@ -49,7 +50,8 @@ namespace cxxtools
                 : _ts(0),
                   _level(1),
                   _lastLevel(0),
-                  _beautify(false)
+                  _beautify(false),
+                  _inputUtf8(false)
             {
                 begin(ts);
             }
@@ -94,6 +96,10 @@ namespace cxxtools
 
             void beautify(bool sw)    { _beautify = sw; }
 
+            bool inputUtf8() const    { return _inputUtf8; }
+
+            void inputUtf8(bool sw)   { _inputUtf8 = sw; }
+
             void beginValue(const std::string& name);
 
             void finishValue();
@@ -107,6 +113,7 @@ namespace cxxtools
             unsigned _level;
             unsigned _lastLevel;
             bool _beautify;
+            bool _inputUtf8;
     };
 
 }

--- a/include/cxxtools/jsonserializer.h
+++ b/include/cxxtools/jsonserializer.h
@@ -125,6 +125,10 @@ namespace cxxtools
 
             void beautify(bool sw)    { _formatter.beautify(sw); }
 
+            bool inputUtf8() const     { return _formatter.inputUtf8(); }
+
+            void inputUtf8(bool sw)    { _formatter.inputUtf8(sw); }
+
             template <typename T>
             static std::string toString(const T& type, const std::string& name, bool beautify = false)
             {

--- a/src/jsonformatter.cpp
+++ b/src/jsonformatter.cpp
@@ -336,7 +336,8 @@ void JsonFormatter::stringOut(const std::string& str)
         else if (*it == '\t')
             *_ts << L'\\'
                 << L't';
-        else if (static_cast<unsigned char>(*it) >= 0x80 || static_cast<unsigned char>(*it) < 0x20)
+        else if ((!_inputUtf8 && static_cast<unsigned char>(*it) >= 0x80) ||
+                                 static_cast<unsigned char>(*it) < 0x20)
         {
             *_ts << L'\\'
                  << L'u';

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -35,7 +35,7 @@ namespace cxxtools
 
 JsonSerializer::JsonSerializer(std::ostream& os,
     TextCodec<Char, char>* codec)
-    : _ts(new TextOStream(os, codec ? codec : new Utf8Codec())),
+    : _ts(new TextOStream(os, codec)),
       _inObject(false)
 {
     _formatter.begin(*_ts);
@@ -45,7 +45,7 @@ JsonSerializer& JsonSerializer::begin(std::ostream& os,
     TextCodec<Char, char>* codec)
 {
     delete _ts;
-    _ts = new TextOStream(os, codec ? codec : new Utf8Codec());
+    _ts = new TextOStream(os, codec);
     _formatter.begin(*_ts);
     return *this;
 }

--- a/test/jsonserializer-test.cpp
+++ b/test/jsonserializer-test.cpp
@@ -76,6 +76,7 @@ class JsonSerializerTest : public cxxtools::unit::TestSuite
             registerMethod("testMultipleObjects", *this, &JsonSerializerTest::testMultipleObjects);
             registerMethod("testPlainEmpty", *this, &JsonSerializerTest::testPlainEmpty);
             registerMethod("testEmptyObject", *this, &JsonSerializerTest::testEmptyObject);
+            registerMethod("testInputUtf8", *this, &JsonSerializerTest::testInputUtf8);
         }
 
         void testInt()
@@ -232,6 +233,16 @@ class JsonSerializerTest : public cxxtools::unit::TestSuite
             serializer.finish();
 
             CXXTOOLS_UNIT_ASSERT_EQUALS(out.str(), "{}");
+        }
+
+        void testInputUtf8()
+        {
+            std::string str("Euro sign: \342\202\254");
+            std::ostringstream out;
+            cxxtools::JsonSerializer serializer(out);
+            serializer.inputUtf8(true);
+            serializer.serialize(str).finish();
+            CXXTOOLS_UNIT_ASSERT_EQUALS(out.str(), "\"" + str + "\"");
         }
 
 };


### PR DESCRIPTION
The JSON serializer assumes that std::string and char* values are
encoded as Latin1, while cxxtools::String are unicode strings (using
characters from the BMP). This is impractical when serializing UTF-8
data. Instead of converting from UTF-8 to cxxtools::String and then using
the \uXXXX notation, add a flag inputUtf8 to tell the serializer that
std::string and char* values are UTF-8 encoded and can be inserted into
the UTF-8 JSON verbatim.

This is a backport of https://github.com/maekitalo/cxxtools/pull/17. The
UTF-8 codec in jsonserializer.cpp is disabled, to mimic the behavior of
9669f655f23c ("Optimize json serializer").

Replay of PR #4 to apply on release branch now that it was tested well on master images