### PR TITLE
Bugfix/base64

### DIFF
--- a/src/base64codec.cpp
+++ b/src/base64codec.cpp
@@ -80,7 +80,7 @@ Base64Codec::result Base64Codec::do_in(MBState& s,
     fromNext = fromBegin;
     toNext = toBegin;
 
-    while( (fromEnd - fromNext) >= 4 && (toEnd - toNext) >= 3 )
+    while ( (fromEnd - fromNext) >= 4 && (toEnd - toNext) >= 3 )
     {
         uint8_t first  = fromBase64( *(fromNext++) );
         uint8_t second = fromBase64( *(fromNext++) );
@@ -89,14 +89,14 @@ Base64Codec::result Base64Codec::do_in(MBState& s,
 
         *(toNext++) = (first << 2) + (second >> 4);
 
-        if(third != 64)
+        if (third != 64)
             *(toNext++) = (second << 4) + (third >> 2);
 
-        if(fourth != 64)
+        if (fourth != 64)
             *(toNext++) = (third << 6) + (fourth);
     }
 
-    if( fromEnd == fromNext )
+    if ( fromEnd == fromNext )
         return std::codecvt_base::ok;
 
     return std::codecvt_base::partial;
@@ -114,81 +114,23 @@ Base64Codec::result Base64Codec::do_out(cxxtools::MBState& state,
     fromNext = fromBegin;
     toNext = toBegin;
 
-    const char* first = 0;
-    const char* second = 0;
-    const char* third = 0;
-
-    if(fromEnd - fromNext < 1)
-        return std::codecvt_base::partial;
-
-    if(toEnd - toNext < 4)
-        return std::codecvt_base::partial;
-
-    switch( state.n )
+    while (fromEnd - fromNext > 0)
     {
-        case 2:
-            first  = &state.value.mbytes[0];
-            second = &state.value.mbytes[1];
-            third  = fromNext++;
-            break;
-
-        case 1:
-            if(fromEnd - fromNext < 2)
-            {
-                state.value.mbytes[1] = *fromNext++;
-                state.n = 2;
-                return std::codecvt_base::partial;
-            }
-
-            first  = &state.value.mbytes[0];
-            second = fromNext++;
-            third  = fromNext++;
-            break;
-
-        default:
-            first  = fromNext++;
-            second = fromNext++;
-            third  = fromNext++;
-            break;
-    }
-
-    while (true)
-    {
-        *toNext++   = toBase64( (static_cast<unsigned char>(*first) >> 2) & 0x3f );
-        *(toNext++) = toBase64( ((static_cast<unsigned char>(*first) << 4) + (static_cast<unsigned char>(*second) >> 4)) & 0x3f );
-        *(toNext++) = toBase64( (static_cast<unsigned char>(*second << 2) + (static_cast<unsigned char>(*third) >> 6)) & 0x3f );
-        *(toNext++) = toBase64( static_cast<unsigned char>(*third) & 0x3f );
-
-        if(toEnd - toNext < 4)
+        if (state.n == 3)
         {
-            state = MBState();
-            return std::codecvt_base::partial;
+            if (toEnd - toNext < 4)
+                return std::codecvt_base::partial;
+
+            *toNext++   = toBase64( (static_cast<unsigned char>(state.value.mbytes[0]) >> 2) & 0x3f );
+            *(toNext++) = toBase64( ((static_cast<unsigned char>(state.value.mbytes[0]) << 4)
+                                        + (static_cast<unsigned char>(state.value.mbytes[1]) >> 4)) & 0x3f );
+            *(toNext++) = toBase64( (static_cast<unsigned char>(state.value.mbytes[1] << 2)
+                                        + (static_cast<unsigned char>(state.value.mbytes[2]) >> 6)) & 0x3f );
+            *(toNext++) = toBase64( static_cast<unsigned char>(state.value.mbytes[2]) & 0x3f );
+            state.n = 0;
         }
 
-        if( fromEnd - fromNext < 3 )
-            break;
-
-        first =  fromNext++;
-        second = fromNext++;
-        third =  fromNext++;
-    }
-
-    switch( fromEnd - fromNext )
-    {
-        case 2:
-            state.value.mbytes[0] = *fromNext++;
-            state.value.mbytes[1] = *fromNext++;
-            state.n = 2;
-            break;
-
-        case 1:
-            state.value.mbytes[0] = *fromNext++;
-            state.n = 1;
-            break;
-
-        default:
-            state = MBState();
-            break;
+        state.value.mbytes[state.n++] = *fromNext++;
     }
 
     return std::codecvt_base::ok;
@@ -202,16 +144,24 @@ Base64Codec::result Base64Codec::do_unshift(MBState& state,
 {
     toNext = toBegin;
 
-    if(toEnd - toBegin < 4)
-    {
+    if (toEnd - toBegin < 4)
         return std::codecvt_base::partial;
-    }
 
     switch(state.n)
     {
+        case 3:
+            *toNext++   = toBase64( (static_cast<unsigned char>(state.value.mbytes[0]) >> 2) & 0x3f );
+            *(toNext++) = toBase64( ((static_cast<unsigned char>(state.value.mbytes[0]) << 4)
+                                        + (static_cast<unsigned char>(state.value.mbytes[1]) >> 4)) & 0x3f );
+            *(toNext++) = toBase64( (static_cast<unsigned char>(state.value.mbytes[1] << 2)
+                                        + (static_cast<unsigned char>(state.value.mbytes[2]) >> 6)) & 0x3f );
+            *(toNext++) = toBase64( static_cast<unsigned char>(state.value.mbytes[2]) & 0x3f );
+            break;
+
         case 2:
             *toNext++   = toBase64( (static_cast<unsigned char>(state.value.mbytes[0]) >> 2) & 0x3f );
-            *(toNext++) = toBase64( ((static_cast<unsigned char>(state.value.mbytes[0]) << 4) + (static_cast<unsigned char>(state.value.mbytes[1]) >> 4)) & 0x3f );
+            *(toNext++) = toBase64( ((static_cast<unsigned char>(state.value.mbytes[0]) << 4)
+                                        + (static_cast<unsigned char>(state.value.mbytes[1]) >> 4)) & 0x3f );
             *(toNext++) = toBase64( (static_cast<unsigned char>(state.value.mbytes[1]) << 2) &  0x3f );
             *(toNext++) = '=';
             break;

--- a/src/base64codec.cpp
+++ b/src/base64codec.cpp
@@ -66,7 +66,36 @@ inline uint8_t fromBase64(char b64)
     return b64dec[(int)b64];
 }
 
+// returns number of available non space bytes up to N
+unsigned short numBytesN(unsigned short N, const MBState& s, const char* fromBegin, const char* fromEnd)
+{
+    unsigned short count = s.n;
+    while (count < N && fromBegin < fromEnd)
+        if (!std::isspace(*fromBegin++))
+            ++count;
+    return count;
 }
+
+// returns the next non space byte
+char readByte(MBState& s, const char*& fromNext)
+{
+    if (s.n > 0)
+    {
+        char ret = s.value.mbytes[0];
+        std::memmove(s.value.mbytes, s.value.mbytes + 1, s.n - 1);
+        --s.n;
+        return ret;
+    }
+    else
+    {
+        while (std::isspace(*fromNext))
+            ++fromNext;
+        return *fromNext++;
+    }
+}
+
+}
+
 
 
 Base64Codec::result Base64Codec::do_in(MBState& s,
@@ -80,12 +109,12 @@ Base64Codec::result Base64Codec::do_in(MBState& s,
     fromNext = fromBegin;
     toNext = toBegin;
 
-    while ( (fromEnd - fromNext) >= 4 && (toEnd - toNext) >= 3 )
+    while ( numBytesN(4, s, fromNext, fromEnd) >= 4 && (toEnd - toNext) >= 3 )
     {
-        uint8_t first  = fromBase64( *(fromNext++) );
-        uint8_t second = fromBase64( *(fromNext++) );
-        uint8_t third  = fromBase64( *(fromNext++) );
-        uint8_t fourth = fromBase64( *(fromNext++) );
+        uint8_t first  = fromBase64(readByte(s, fromNext));
+        uint8_t second = fromBase64(readByte(s, fromNext));
+        uint8_t third  = fromBase64(readByte(s, fromNext));
+        uint8_t fourth = fromBase64(readByte(s, fromNext));
 
         *(toNext++) = (first << 2) + (second >> 4);
 
@@ -96,10 +125,17 @@ Base64Codec::result Base64Codec::do_in(MBState& s,
             *(toNext++) = (third << 6) + (fourth);
     }
 
-    if ( fromEnd == fromNext )
-        return std::codecvt_base::ok;
+    while (fromNext < fromEnd && s.n < 4)
+    {
+        while (fromNext < fromEnd && std::isspace(*fromNext))
+            ++fromNext;
+        if (fromNext < fromEnd)
+            s.value.mbytes[s.n++] = *fromNext++;
+    }
 
-    return std::codecvt_base::partial;
+    return numBytesN(1, s, fromNext, fromEnd) > 0
+                ? std::codecvt_base::partial
+                : std::codecvt_base::ok;
 }
 
 

--- a/test/base64-test.cpp
+++ b/test/base64-test.cpp
@@ -30,13 +30,17 @@
 #include "cxxtools/base64stream.h"
 #include "cxxtools/unit/testsuite.h"
 #include "cxxtools/unit/registertest.h"
+#include "cxxtools/log.h"
+
+log_define("cxxtools.test.base64")
 
 class Base64Test : public cxxtools::unit::TestSuite
 {
         static std::string encodeDecode(const std::string& data)
         {
-            return cxxtools::decode<cxxtools::Base64Codec>(
-                      cxxtools::encode<cxxtools::Base64Codec>(data));
+            std::string b = cxxtools::encode<cxxtools::Base64Codec>(data);
+            log_debug("data.size=" << data.size() << " data=\"" << data << "\" base64.size=" << b.size() << " base64=" << b);
+            return cxxtools::decode<cxxtools::Base64Codec>(b);
         }
 
     public:
@@ -51,6 +55,7 @@ class Base64Test : public cxxtools::unit::TestSuite
             registerMethod("encodeStreamTest2", *this, &Base64Test::encodeStreamTest2);
             registerMethod("encodeDecodeTest", *this, &Base64Test::encodeDecodeTest);
             registerMethod("binaryTest", *this, &Base64Test::binaryTest);
+            registerMethod("artemTest", *this, &Base64Test::artemTest);
         }
 
         void encodeTest0()
@@ -183,6 +188,15 @@ class Base64Test : public cxxtools::unit::TestSuite
             CXXTOOLS_UNIT_ASSERT_EQUALS(data, data2);
         }
 
+        void artemTest()
+        {
+            for (unsigned n = 0; n < 256; ++n)
+            {
+                std::string data(n, 'a');
+                std::string data2 = encodeDecode(data);
+                CXXTOOLS_UNIT_ASSERT_EQUALS(data, data2);
+            }
+        }
 };
 
 cxxtools::unit::RegisterTest<Base64Test> register_Base64Test;


### PR DESCRIPTION
`cxxtools::Base64Codec` is buggy, backport the upstream fixes. Empirically tested with hundred of megabytes of `/dev/urandom` data where the fixed version always managed to decode itself correctly.